### PR TITLE
nuxt-link to current page black + menu sidebar always full viewport height

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -38,12 +38,12 @@ onMounted(() => {
   }
 
   body {
-    width: 100vw;
+    width: 100%;
     min-width: 480px;
-    min-height: 100vh;
+    min-height: 100%;
 
     #__nuxt {
-      height: 100vh;
+      height: 100%;
     }
   }
 
@@ -77,7 +77,7 @@ onMounted(() => {
 
     display: flex;
     flex-flow: column;
-    height: 100%;
+    min-height: 100%;
 
     #container2 {
       flex: 1 1 auto;

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -33,13 +33,26 @@ onMounted(() => {
   @use "../assets/globalStyles";
   @use "../assets/styleConfig";
 
+  html {
+    height: 100%;
+  }
+
   body {
-    width: 100%;
+    width: 100vw;
     min-width: 480px;
+    min-height: 100vh;
+
+    #__nuxt {
+      height: 100vh;
+    }
   }
 
   .router-link-active{
     cursor: auto;
+    color: #000;
+    &:hover {
+      color: #000;
+    }
   }
 
   .v-btn {
@@ -62,12 +75,17 @@ onMounted(() => {
     min-width: 480px;
     width: 100%;
 
+    display: flex;
+    flex-flow: column;
+    height: 100%;
+
     #container2 {
+      flex: 1 1 auto;
+
       @media (min-width: 800px) {
         display: flex;
         justify-content: center;
         align-items: stretch;
-        overflow: auto;
 
         #maincontainer {
           flex-grow: 1;
@@ -102,6 +120,7 @@ onMounted(() => {
   }
 
   #header {
+    flex: 0 1 auto;
     background-color: styleConfig.$headerBackgroundColor;
 
     #logo {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - App now uses a full-height, column-based layout for consistent page sizing.
  - Header sizing and positioning stabilized for predictable top layout.
  - Active navigation links display black text and remain black on hover.
  - Body uses viewport-based sizing for better fit across screens.

- Refactor
  - Containers reorganized with flex behavior for predictable stacking and a flexible content area.
  - Overflow handling removed at larger widths to simplify layout flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->