### PR TITLE
option to see plot of full list (vs just top 100)

### DIFF
--- a/app/assets/graphColors.scss
+++ b/app/assets/graphColors.scss
@@ -49,13 +49,7 @@ $color8: rgb(153,153,153);
   &-7 {
     @include color($color7)
   }
-  &-8 {
-    @include color($color8)
-  }
-  &-9 {
-    @include color($color8)
-  }
-  &-10 {
+  &-other {
     @include color($color8)
   }
 }

--- a/app/components/d3/AgesGraph.vue
+++ b/app/components/d3/AgesGraph.vue
@@ -40,7 +40,7 @@
 import {useRootStore} from "~/stores/root";
 
 const {fullWidth, fullHeight, width, height, margin} = useGraphConstants()
-const {years, xScale, yScale} = useGraph()
+const {years, xBandScale, xScale, yScale} = useGraph()
 
 const yStep = computed(() => {
   return yScale.value(1) - yScale.value(0);
@@ -64,7 +64,7 @@ const points = computed(() => {
   return points;
 })
 
-const {onHover, hoverYear, hoverPosition, hoverLineX, tooltipStyle} = useGraphHover(xScale, yScale, years)
+const {onHover, hoverYear, hoverPosition, hoverLineX, tooltipStyle} = useGraphHover(xBandScale, xScale, yScale, years)
 
 const tooltipSong = computed(() => {
   if (!!hoverYear.value && !!hoverPosition.value) {

--- a/app/components/d3/Axes.vue
+++ b/app/components/d3/Axes.vue
@@ -39,13 +39,25 @@ const props = defineProps({
   xScale: Function,
   yScale: Function,
   years: Array,
-  hoverYear: Year
+  hoverYear: Year,
+  extended: {
+    type: Boolean,
+    default: false
+  }
 })
 
-const yTickValues = [1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+const {width} = useGraphConstants()
+
+const yTickValues = computed(() => {
+  if (props.extended) {
+    return [1, 100, 250, 500, 750, 1000, 1250, 1500, 1750, 2000]
+  } else {
+    return [1, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+  }
+})
 
 const rightX = computed(() => {
-  return props.xScale.range()[1];
+  return width;
 })
 
 function isHoverYear(year) {

--- a/app/components/d3/Axes.vue
+++ b/app/components/d3/Axes.vue
@@ -2,7 +2,7 @@
 g
   g.x.axis
     path.domain(:d='`M0,0 H ${rightX}`')
-    template(v-for='year in years' key='year.yyyy')
+    template(v-for='year in years' :key='year.yyyy')
       g.tick(
         v-if='year.yyyy % 10 === 0 && !isHoverYear(year)'
         :transform='`translate(${xScale(year._yy)},0)`'

--- a/app/components/d3/DistributionGraph.vue
+++ b/app/components/d3/DistributionGraph.vue
@@ -44,8 +44,8 @@ div
 
 <script setup>
   const {fullWidth, fullHeight, width, height, margin} = useGraphConstants()
-  const {years, xScale, yScale} = useGraph()
-  const {onHover, hoverYear, hoverLineX, hoverPosition, tooltipStyle} = useGraphHover(xScale, yScale, years)
+  const {years, xBandScale, xScale, yScale} = useGraph()
+  const {onHover, hoverYear, hoverLineX, hoverPosition, tooltipStyle} = useGraphHover(xBandScale, xScale, yScale, years)
 
   const props = defineProps({
     title: {

--- a/app/components/d3/Graph.vue
+++ b/app/components/d3/Graph.vue
@@ -33,7 +33,7 @@
           }]"
       )
         path.coloredPath(:d='fullSongLine(song)')
-        template(v-for='year in years' key='year.yyyy')
+        template(v-for='year in years' :key='year.yyyy')
           circle.circle.coloredCircle(
             v-if='song.position(year, extended)'
             :cx='xScale(year._yy)'

--- a/app/components/d3/StationaryGraph.vue
+++ b/app/components/d3/StationaryGraph.vue
@@ -39,8 +39,8 @@
   import {useRootStore} from "~/stores/root";
 
   const {fullWidth, fullHeight, width, height, margin} = useGraphConstants()
-  const {years, xScale, yScale, songLine} = useGraph()
-  const {onHover, hoverYear, hoverLineX, hoverPosition, tooltipStyle} = useGraphHover(xScale, yScale, years)
+  const {years, xBandScale, xScale, yScale, songLine} = useGraph()
+  const {onHover, hoverYear, hoverLineX, hoverPosition, tooltipStyle} = useGraphHover(xBandScale, xScale, yScale, years)
 
   defineProps({
     songs: Array

--- a/app/composables/useGraphEntries.js
+++ b/app/composables/useGraphEntries.js
@@ -1,0 +1,21 @@
+export default function (songs) {
+  const top100Songs = []
+  const fullListSongs = []
+  const { years } = storeToRefs(useYearStore())
+  songs.forEach(song => {
+    if (song.listCount(years.value) > 0) {
+      top100Songs.push(song)
+    } else {
+      fullListSongs.push(song)
+    }
+  })
+
+  const entries = []
+  top100Songs.forEach(song => {
+    entries.push({song, isTop100: true})
+  })
+  fullListSongs.forEach(song => {
+    entries.push({song, isTop100: false})
+  })
+  return entries
+}

--- a/app/composables/useGraphEntries.js
+++ b/app/composables/useGraphEntries.js
@@ -1,21 +1,15 @@
 export default function (songs) {
-  const top100Songs = []
-  const fullListSongs = []
   const { years } = storeToRefs(useYearStore())
-  songs.forEach(song => {
-    if (song.listCount(years.value) > 0) {
-      top100Songs.push(song)
-    } else {
-      fullListSongs.push(song)
+  return computed(() => {
+    const top = []
+    const rest = []
+    for (const song of songs) {
+      if (song?.listCount?.(years.value) > 0) {
+        top.push({ song, isTop100: true })
+      } else {
+        rest.push({ song, isTop100: false })
+      }
     }
+    return top.concat(rest)
   })
-
-  const entries = []
-  top100Songs.forEach(song => {
-    entries.push({song, isTop100: true})
-  })
-  fullListSongs.forEach(song => {
-    entries.push({song, isTop100: false})
-  })
-  return entries
 }

--- a/app/composables/useGraphHover.js
+++ b/app/composables/useGraphHover.js
@@ -1,7 +1,7 @@
 
 import {bisect} from "d3-array";
 
-export default function (xScale, yScale, years) {
+export default function (xBandScale, xScale, yScale, years) {
   const {width, height, margin} = useGraphConstants()
 
   const hoverYear = ref(undefined)
@@ -13,7 +13,7 @@ export default function (xScale, yScale, years) {
     if (hoverYear.value) {
       return xScale.value(hoverYear.value._yy);
     } else {
-      return xScale.value.range()[1];
+      return undefined;
     }
   })
 
@@ -23,11 +23,11 @@ export default function (xScale, yScale, years) {
       const tooltipTopScreen = (tooltipTop * overlayScreenHeight.value / height) + "px";
 
       if (hoverLineX.value > width - 200) {
-        const tooltipRight = (margin.right + width - hoverLineX.value + xScale.value.step() * 4/5);
+        const tooltipRight = (margin.right + width - hoverLineX.value + xBandScale.value.step() * 4/5);
         const tooltipRightScreen = (tooltipRight * overlayScreenWidth.value / width) + "px";
         return {right: tooltipRightScreen, top: tooltipTopScreen};
       } else {
-        const tooltipLeft = (margin.left + hoverLineX.value + xScale.value.step() * 2/3);
+        const tooltipLeft = (margin.left + hoverLineX.value + xBandScale.value.step() * 2/3);
         const tooltipLeftScreen = (tooltipLeft * overlayScreenWidth.value / width) + "px";
         return {left: tooltipLeftScreen, top: tooltipTopScreen};
       }
@@ -58,7 +58,7 @@ export default function (xScale, yScale, years) {
     overlayScreenWidth.value = boundingClientRect.width;
     overlayScreenHeight.value = boundingClientRect.height;
 
-    const starts = years.value.map(year => xScale.value(year._yy) - xScale.value.step() / 2);
+    const starts = years.value.map(year => xScale.value(year._yy) - xBandScale.value.step() / 2);
     const lookup = width / overlayScreenWidth.value * offsetX - margin.left;
     const newHoverYear = years.value[bisect(starts, lookup) - 1];
     if (newHoverYear) {

--- a/app/pages/album/[id].vue
+++ b/app/pages/album/[id].vue
@@ -15,7 +15,7 @@ div
     | uit {{ album.releaseYear }}.
 
   ui-tabs(:tabs="tabs")
-    nuxt-page(:album="album" :top100-songs="top100Songs" :full-album-data="fullAlbumData")
+    nuxt-page(:album="album" :songs="songs" :full-album-data="fullAlbumData")
 </template>
 
 <script setup>
@@ -41,17 +41,17 @@ div
       .find(albumId.value);
   })
 
-  const top100Songs = computed(() => {
-    return album.value.songsSorted.filter(song => song.listCount(years.value) > 0)
+  const songs = computed(() => {
+    return album.value.songsSorted
   })
 
   const tabs = computed(() => {
-    const tabs = [{ to: `/album/${albumId.value}`, title: `Nummers in de Tijdloze` }]
-    if (top100Songs.value.length) {
-      tabs.push({ to: `/album/${albumId.value}/grafiek`, title: 'Op grafiek', subtitle: "top 100" })
-    }
-    tabs.push({ to: `/album/${albumId.value}/info`, title: 'Info' })
-    return tabs
+    const prefix = `/album/${albumId.value}-${album.value.slug}`
+    return [
+      { to: prefix, title: `Nummers in de Tijdloze` },
+      { to: `${prefix}/grafiek`, title: 'Op grafiek' },
+      { to: `${prefix}/info`, title: 'Info' }
+    ]
   })
 
   definePageMeta({

--- a/app/pages/album/[id]/grafiek.vue
+++ b/app/pages/album/[id]/grafiek.vue
@@ -1,11 +1,16 @@
 <template lang="pug">
-d3-graph(:songs='top100Songs')
+d3-graph(:entries='entries')
 </template>
 
 <script setup>
 const props = defineProps({
-  top100Songs: Object
+  songs: {
+    type: Array,
+    required: true
+  }
 })
+
+const entries = useGraphEntries(props.songs)
 </script>
 
 <style lang="scss" scoped>

--- a/app/pages/artiest/[id].vue
+++ b/app/pages/artiest/[id].vue
@@ -7,7 +7,7 @@ div
     ui-admin-link-btn(:to="`/admin/artist/${artist.id}`") Admin: artist aanpassen
 
   ui-tabs(:tabs="tabs")
-    nuxt-page(:artist="artist" :top100-songs="top100Songs" :full-artist-data="fullArtistData")
+    nuxt-page(:artist="artist" :songs="songs" :full-artist-data="fullArtistData")
 </template>
 
 <script setup>
@@ -46,17 +46,17 @@ div
         .find(artistId.value);
   })
 
-  const top100Songs = computed(() => {
-    return artist.value.allSongs.filter(song => song.listCount(years.value) > 0)
+  const songs = computed(() => {
+    return artist.value.allSongs
   })
 
   const tabs = computed(() => {
-    const tabs = [{ to: `/artiest/${artistId.value}`, title: `Nummers in de Tijdloze` }]
-    if (top100Songs.value.length) {
-      tabs.push({ to: `/artiest/${artistId.value}/grafiek`, title: 'Op grafiek', subtitle: "top 100" })
-    }
-    tabs.push({ to: `/artiest/${artistId.value}/info`, title: 'Info' })
-    return tabs
+    const prefix = `/artiest/${artistId.value}-${artist.value.slug}`
+    return [
+      { to: prefix, title: `Nummers in de Tijdloze` },
+      { to: `${prefix}/grafiek`, title: 'Op grafiek' },
+      { to: `${prefix}/info`, title: 'Info' }
+    ]
   })
 
   definePageMeta({

--- a/app/pages/artiest/[id]/grafiek.vue
+++ b/app/pages/artiest/[id]/grafiek.vue
@@ -1,11 +1,18 @@
 <template lang="pug">
-d3-graph(:songs='top100Songs')
+d3-graph(:entries='entries')
 </template>
 
 <script setup>
+import useGraphEntries from "~/composables/useGraphEntries";
+
 const props = defineProps({
-  top100Songs: Array
+  songs: {
+    type: Array,
+    required: true
+  }
 })
+
+const entries = useGraphEntries(props.songs)
 </script>
 
 <style lang="scss" scoped>

--- a/app/pages/artiest/[id]/index.vue
+++ b/app/pages/artiest/[id]/index.vue
@@ -9,7 +9,10 @@
 
 <script setup>
 const props = defineProps({
-  artist: Object
+  artist: {
+    type: Object,
+    required: true
+  }
 })
 
 const byAlbum = ref(false)

--- a/app/pages/nummer/[id].vue
+++ b/app/pages/nummer/[id].vue
@@ -43,16 +43,15 @@ const song = computed(() => {
   return useRepo(Song).withAll().find(songId.value);
 })
 const tabs = computed(() => {
+  const prefix = `/nummer/${songId.value}-${song.value.slug}`
   const tabs = [
-      { to: `/nummer/${songId.value}`, title: `In de Tijdloze` }
+    { to: prefix, title: `In de Tijdloze` },
+    { to: `${prefix}/grafiek`, title: 'Op grafiek' }
   ]
-  if (song.value.listCount(years.value) > 0) {
-    tabs.push({ to: `/nummer/${songId.value}/grafiek`, title: 'Op grafiek', subtitle: "top 100" })
-  }
   if (fullSongData.value.lyrics) {
-    tabs.push({ to: `/nummer/${songId.value}/lyrics`, title: 'Lyrics' })
+    tabs.push({ to: `${prefix}/lyrics`, title: 'Lyrics' })
   }
-  tabs.push({ to: `/nummer/${songId.value}/info`, title: 'Info' })
+  tabs.push({ to: `${prefix}/info`, title: 'Info' })
   return tabs
 })
 

--- a/app/pages/nummer/[id]/grafiek.vue
+++ b/app/pages/nummer/[id]/grafiek.vue
@@ -1,11 +1,15 @@
 <template lang="pug">
-d3-graph(:songs='[song]' no-label)
+d3-graph(:entries='entries' no-label)
 </template>
 
 <script setup>
 const props = defineProps({
-  song: Object
+  song: {
+    type: Object,
+    required: true
+  }
 })
+const entries = useGraphEntries([props.song])
 </script>
 
 <style lang="scss" scoped>

--- a/app/stores/root.js
+++ b/app/stores/root.js
@@ -65,6 +65,14 @@ export const useRootStore = defineStore('root', () => {
     }
   })
 
+  const maxPositionByYyyy = computed(() => {
+    const result = {}
+    useRepo(List).all().forEach(list => {
+      result[list.year] = list.songIds.length
+    })
+    return result
+  })
+
   function list(year, limit, maxPosition) {
     const list = useRepo(List).find(year?.yyyy)
     if (list) {
@@ -113,6 +121,7 @@ export const useRootStore = defineStore('root', () => {
     lastSong,
     list,
     listInProgress,
+    maxPositionByYyyy,
     songIdsByTitle,
     songs,
     usedCountryIds


### PR DESCRIPTION
resolves #71 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Graphs can toggle between Top 100 and full list (extended mode) with alternate y-axis tick sets and a grey background.
  - Legend and line coloring now distinguish Top 100 entries from others and handle many non-Top100 items.

- **Changes**
  - Album, artist, and song pages now show all songs and always include a Graph tab; routes use slugged URLs.
  - Hover and tooltip positioning improved for banded/year-aligned layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->