### PR TITLE
fix for loading wikipedia content

### DIFF
--- a/app/components/WikipediaContent.vue
+++ b/app/components/WikipediaContent.vue
@@ -1,10 +1,10 @@
 <template lang="pug">
-div.mt-5.mb-7(v-if="url")
+div.mt-5.mb-7
   div.title Wikipedia ({{language}})
   template(v-if="sanitizedContent")
     div.details
       div Inhoud van Wikipedia met licentie #[a(href="https://creativecommons.org/licenses/by-sa/4.0/deed.nl") Creative Commons BY-SA 4.0]
-      div Laatst geladen: {{wikipediaContentNl['lastUpdate']}}
+      div Laatst geladen: {{wikipediaContent['lastUpdate']}}
     div.px-5.mt-2.wikipediaContent(v-html="sanitizedContent")
   div(v-else)
     v-progress-circular(indeterminate size="small")
@@ -16,18 +16,24 @@ div.mt-5.mb-7(v-if="url")
 import sanitizeHtml from 'sanitize-html';
 
 const props = defineProps({
-  language: String,
-  url: String,
+  language: {
+    type: String,
+    required: true
+  },
+  url: {
+    type: String,
+    required: true
+  }
 })
 
-const {data: wikipediaContentNl, error} = await useLazyFetch(
+const {data: wikipediaContent, error} = await useLazyFetch(
   `wikipedia/find`, useFetchOpts({
     query: {url: props.url}
   })
 )
 
 const sanitizedContent = computed(() => {
-  const content = wikipediaContentNl.value?.['content']
+  const content = wikipediaContent.value?.['content']
   if (content) {
     return sanitizeHtml(content, {
       allowedTags: ['p', 'i', 'b'],

--- a/app/pages/album/[id]/info.vue
+++ b/app/pages/album/[id]/info.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   template(v-if="status === 'success'")
-    wikipedia-content(:url="fullAlbumData['urlWikiNl']" language="Nederlands")
-    wikipedia-content(:url="fullAlbumData['urlWikiEn']" language="Engels")
+    wikipedia-content(v-if="fullAlbumData['urlWikiNl']" :url="fullAlbumData['urlWikiNl']" language="Nederlands")
+    wikipedia-content(v-if="fullAlbumData['urlWikiEn']" :url="fullAlbumData['urlWikiEn']" language="Engels")
     p.links(v-if="links.length")
       | Externe links:
       template(v-for="(link, index) in links" :key="index")

--- a/app/pages/artiest/[id]/info.vue
+++ b/app/pages/artiest/[id]/info.vue
@@ -9,8 +9,8 @@
       nuxt-link(:to="`/database?type=artiesten&land=${artist.countryId}`")
         strong
           country-icon(:country-id="artist.countryId" :include-name="true")
-    wikipedia-content(:url="fullArtistData['urlWikiNl']" language="Nederlands")
-    wikipedia-content(:url="fullArtistData['urlWikiEn']" language="Engels")
+    wikipedia-content(v-if="fullArtistData['urlWikiNl']" :url="fullArtistData['urlWikiNl']" language="Nederlands")
+    wikipedia-content(v-if="fullArtistData['urlWikiEn']" :url="fullArtistData['urlWikiEn']" language="Engels")
     p.links(v-if="links.length")
       | Externe links:
       template(v-for="(link, index) in links" :key="index")

--- a/app/pages/nummer/[id]/info.vue
+++ b/app/pages/nummer/[id]/info.vue
@@ -11,8 +11,8 @@
       | Taal:
       |
       strong {{languages[song.languageId]}}
-    wikipedia-content(:url="fullSongData['urlWikiNl']" language="Nederlands")
-    wikipedia-content(:url="fullSongData['urlWikiEn']" language="Engels")
+    wikipedia-content(v-if="fullSongData['urlWikiNl']" :url="fullSongData['urlWikiNl']" language="Nederlands")
+    wikipedia-content(v-if="fullSongData['urlWikiEn']" :url="fullSongData['urlWikiEn']" language="Engels")
     p.links(v-if="links.length")
       | Externe links:
       template(v-for='(link, index) in links' :key='index')


### PR DESCRIPTION
resolves #82 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Wikipedia sections now display only when a valid URL is available, preventing empty or broken blocks.
  - Ensured the “Last updated” timestamp and content display consistently for Wikipedia entries.

- Refactor
  - Tightened component inputs with required language and URL, improving reliability.
  - Standardized internal data handling for fetched Wikipedia content across pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->