### PR TITLE
reload core data on websocket reconnect

### DIFF
--- a/app/plugins/websocket.client.js
+++ b/app/plugins/websocket.client.js
@@ -124,7 +124,9 @@ export default defineNuxtPlugin( nuxtApp => {
         pollStore.currentPoll = response.poll
       }
     },
-    onreconnect: e => {},
+    onreconnect: async e => {
+      await reloadCoreData()
+    },
     onmaximum: e => {},
     onclose: e => {},
     onerror: e => {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where app data wasn't refreshing after losing and restoring the server connection. The app now automatically reloads core data when the connection is restored.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->